### PR TITLE
INFRA-817 Allow disabling propogation settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -171,6 +171,7 @@ Default Settings
 
 :python:`INDENT_CONSOLE_LOG = 2` - Indent console log by "n" spaces.
 
+:python:`PROPOGATION = True` - set this to False to disable propogation of the 'dl_logger' logger
 
 Change Log
 ==========

--- a/django_logging/logger.py
+++ b/django_logging/logger.py
@@ -72,7 +72,7 @@ LOGGING = {
         'dl_logger': {
             'handlers': LOG_HANDLERS,
             'level': LOG_LEVEL,
-            'propagate': True
+            'propagate': settings.PROPOGATE
         },
     }
 }

--- a/django_logging/settings.py
+++ b/django_logging/settings.py
@@ -22,8 +22,6 @@ class DjangoLoggingSettings(object):
             ROTATE_MB=100,
             ROTATE_COUNT=10,
             INDENT_CONSOLE_LOG=2,
-            ELASTICSEARCH_ENABLED=False,
-            ELASTICSEARCH_HOSTS=["localhost"]
         )
 
         try:

--- a/django_logging/settings.py
+++ b/django_logging/settings.py
@@ -22,6 +22,7 @@ class DjangoLoggingSettings(object):
             ROTATE_MB=100,
             ROTATE_COUNT=10,
             INDENT_CONSOLE_LOG=2,
+            PROPOGATE=True
         )
 
         try:


### PR DESCRIPTION
This is useful if you want the django-logging library to catch stuff like requests and exceptions but dont want those events to also keep moving forward downstream.