### PR TITLE
Ensure console logging is done in JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ docs/_build/
 target/
 ./logs
 .idea/
+
+# VSCode
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -169,8 +169,6 @@ Default Settings
 
 :python:`ROTATE_COUNT = 10` - Maximum number of rotated log files.
 
-:python:`INDENT_CONSOLE_LOG = 2` - Indent console log by "n" spaces.
-
 :python:`PROPOGATION = True` - set this to False to disable propogation of the 'dl_logger' logger
 
 Change Log

--- a/django_logging/handlers.py
+++ b/django_logging/handlers.py
@@ -74,23 +74,21 @@ class DebugFileHandler(RotatingFileHandler):
 
 class ConsoleHandler(StreamHandler):
     def emit(self, record):
+        if not isinstance(record.msg, LogObject)\
+                and not isinstance(record.msg, ErrorLogObject)\
+                and not isinstance(record.msg, dict)\
+                and not isinstance(record.msg, Exception):
+            return
         return super(ConsoleHandler, self).emit(record)
 
     def format(self, record):
-        if isinstance(record.msg, LogObject) or isinstance(record.msg, SqlLogObject):
-            created = int(record.created)
+        created = int(record.created)
+        if isinstance(record.msg, dict):
+            message = {record.levelname: {created: record.msg}}
+        else:
             message = {record.levelname: {created: record.msg.to_dict}}
 
-            return json.dumps(message,
-                              sort_keys=True)
-        elif isinstance(record.msg, ErrorLogObject):
-            return str(record.msg)
-        elif isinstance(record.msg, dict):
-            created = int(record.created)
-            message = {record.levelname: {created: record.msg}}
-            return json.dumps(message, sort_keys=True)
-        else:
-            return super(ConsoleHandler, self).format(record)
+        return json.dumps(message, sort_keys=True)
 
 
 class SQLFileHandler(RotatingFileHandler):

--- a/django_logging/handlers.py
+++ b/django_logging/handlers.py
@@ -81,19 +81,14 @@ class ConsoleHandler(StreamHandler):
             created = int(record.created)
             message = {record.levelname: {created: record.msg.to_dict}}
 
-            try:
-                indent = int(settings.INDENT_CONSOLE_LOG)
-            except (ValueError, TypeError):
-                indent = None
             return json.dumps(message,
-                              sort_keys=True,
-                              indent=indent)
+                              sort_keys=True)
         elif isinstance(record.msg, ErrorLogObject):
             return str(record.msg)
         elif isinstance(record.msg, dict):
             created = int(record.created)
             message = {record.levelname: {created: record.msg}}
-            return json.dumps(message, sort_keys=True, indent=2)
+            return json.dumps(message, sort_keys=True)
         else:
             return super(ConsoleHandler, self).format(record)
 

--- a/django_logging/handlers.py
+++ b/django_logging/handlers.py
@@ -82,14 +82,13 @@ class ConsoleHandler(StreamHandler):
         return super(ConsoleHandler, self).emit(record)
 
     def format(self, record):
-        created = int(record.created)
-        if isinstance(record.msg, dict):
-            message = {record.levelname: {created: record.msg}}
-        else:
-            message = {record.levelname: {created: record.msg.to_dict}}
+        message = {'levelname': record.levelname, 'created': int(record.created)}
+        try:
+            message.update(record.msg)
+        except TypeError:
+            message.update(record.msg.to_dict)
 
         return json.dumps(message, sort_keys=True)
-
 
 class SQLFileHandler(RotatingFileHandler):
     def emit(self, record):

--- a/django_logging/settings.py
+++ b/django_logging/settings.py
@@ -21,7 +21,6 @@ class DjangoLoggingSettings(object):
             ENCODING='ascii',
             ROTATE_MB=100,
             ROTATE_COUNT=10,
-            INDENT_CONSOLE_LOG=2,
             PROPOGATE=True
         )
 


### PR DESCRIPTION
To really make this library live up to it's `json` name - let's make the console output also in json. 

This PR also tweaks the output format that typically goes out on the `filehandler`. I'd like to go back in a future PR and modify the entire log structure in all scenarios.

To clarify, the current format for disk output is:

```json
{
    "ERROR":
    {
        "timestamp":
        {
         "LOG_CONTENT_FIELD": "result"
        }
    }
}
```

My change flattens this so I don't have to do freakin' post processing just to unpack that. So I moved it to like so (only for console output atm):

```json
{
    "loglevel": "ERROR",
    "created": "${timestamp}",
    "LOG_CONTENT_FIELD": "result"
}
```

I didn't change everything yet cause we still have servers using the old format but once we get off those we can change this format everywhere.
