### PR TITLE
Add logging handlers only when necessary

### DIFF
--- a/django_logging/logger.py
+++ b/django_logging/logger.py
@@ -7,20 +7,61 @@ import sys
 from . import settings
 
 LOG_LEVEL = settings.LOG_LEVEL.upper()
-LOG_HANDLERS = ['default']
+LOG_HANDLERS = dict()
+
+
+def create_log_directory():
+    """Create root logging directory if it doesn't already exist"""
+
+    if not os.path.exists(settings.LOG_PATH):
+        try:
+            os.makedirs(settings.LOG_PATH)
+        except Exception:
+            raise Exception('Unable to configure logger. Can\'t create LOG_PATH: {}'.format(settings.LOG_PATH))
+
 
 if settings.CONSOLE_LOG:
-    LOG_HANDLERS.append('console')
-if settings.DEBUG:
-    LOG_HANDLERS.append('debug')
-if settings.SQL_LOG:
-    LOG_HANDLERS.append('sql')
+    LOG_HANDLERS['console'] = {
+            'level': 'DEBUG',
+            'class': 'django_logging.handlers.ConsoleHandler',
+            'formatter': 'verbose',
+            'stream': sys.stderr
+        }
 
-if not os.path.exists(settings.LOG_PATH):
-    try:
-        os.makedirs(settings.LOG_PATH)
-    except Exception as e:
-        raise Exception('Unable to configure logger. Can\'t create LOG_PATH: {}'.format(settings.LOG_PATH))
+else:
+    LOG_HANDLERS['default'] = {
+            'level': 'INFO',
+            'class': 'django_logging.handlers.AppFileHandler',
+            'formatter': 'verbose',
+            'maxBytes': settings.ROTATE_MB * 1024 * 1024,
+            'backupCount': settings.ROTATE_COUNT,
+            'filename': '{}/app.log'.format(settings.LOG_PATH)
+        }
+    create_log_directory()
+
+if settings.DEBUG:
+    LOG_HANDLERS['debug'] = {
+            'level': 'DEBUG',
+            'class': 'django_logging.handlers.DebugFileHandler',
+            'formatter': 'verbose',
+            'maxBytes': settings.ROTATE_MB * 1024 * 1024,
+            'backupCount': settings.ROTATE_COUNT,
+            'filename': '{}/debug.log'.format(settings.LOG_PATH)
+        }
+    create_log_directory()
+
+
+if settings.SQL_LOG:
+    LOG_HANDLERS['sql'] = {
+            'level': 'DEBUG',
+            'class': 'django_logging.handlers.SQLFileHandler',
+            'formatter': 'sql',
+            'maxBytes': settings.ROTATE_MB * 1024 * 1024,
+            'backupCount': settings.ROTATE_COUNT,
+            'filename': '{}/sql.log'.format(settings.LOG_PATH)
+        }
+    create_log_directory()
+
 
 LOGGING = {
     'version': 1,
@@ -36,41 +77,10 @@ LOGGING = {
             'format': '[%(levelname)s - %(created)s] %(duration)s %(sql)s %(params)s'
         },
     },
-    'handlers': {
-        'console': {
-            'level': 'DEBUG',
-            'class': 'django_logging.handlers.ConsoleHandler',
-            'formatter': 'verbose',
-            'stream': sys.stderr
-        },
-        'default': {
-            'level': 'INFO',
-            'class': 'django_logging.handlers.AppFileHandler',
-            'formatter': 'verbose',
-            'maxBytes': settings.ROTATE_MB * 1024 * 1024,
-            'backupCount': settings.ROTATE_COUNT,
-            'filename': '{}/app.log'.format(settings.LOG_PATH)
-        },
-        'debug': {
-            'level': 'DEBUG',
-            'class': 'django_logging.handlers.DebugFileHandler',
-            'formatter': 'verbose',
-            'maxBytes': settings.ROTATE_MB * 1024 * 1024,
-            'backupCount': settings.ROTATE_COUNT,
-            'filename': '{}/debug.log'.format(settings.LOG_PATH)
-        },
-        'sql': {
-            'level': 'DEBUG',
-            'class': 'django_logging.handlers.SQLFileHandler',
-            'formatter': 'sql',
-            'maxBytes': settings.ROTATE_MB * 1024 * 1024,
-            'backupCount': settings.ROTATE_COUNT,
-            'filename': '{}/sql.log'.format(settings.LOG_PATH)
-        }
-    },
+    'handlers': LOG_HANDLERS,
     'loggers': {
         'dl_logger': {
-            'handlers': LOG_HANDLERS,
+            'handlers': [h for h in LOG_HANDLERS],
             'level': LOG_LEVEL,
             'propagate': settings.PROPOGATE
         },


### PR DESCRIPTION
While trying to debug using this library under a root-only filesystem, it was uncovered that the handlers will initialize themselves even if they aren't active in a logger.

This means that the file handlers will for instance, try to write to the log file in question even though that's an impossible situation. This re-structure PR only adds the handler to a the logging dictconf when actually being utilized.